### PR TITLE
Fix command defaults for HackIDE

### DIFF
--- a/client/src/hooks/useGameState.ts
+++ b/client/src/hooks/useGameState.ts
@@ -2,6 +2,7 @@ import { useState, useCallback, useEffect } from 'react';
 import { GameState } from '../types/game';
 import { loadGameState, saveGameState } from '../lib/gameStorage';
 import { initializeFactionStandings } from '../lib/factionSystem';
+import { getInitialUnlockedCommands } from '../lib/commands';
 
 export function useGameState() {
   const [gameState, setGameState] = useState<GameState>({
@@ -9,7 +10,7 @@ export function useGameState() {
     credits: 500,
     reputation: 'UNKNOWN',
     completedMissions: 0,
-    unlockedCommands: ['help', 'scan', 'connect', 'status', 'clear'],
+    unlockedCommands: getInitialUnlockedCommands(),
     missionProgress: 0,
     networkStatus: 'DISCONNECTED',
     soundEnabled: true,

--- a/client/src/lib/gameStorage.ts
+++ b/client/src/lib/gameStorage.ts
@@ -2,6 +2,7 @@ import { GameState } from '../types/game';
 import { apiRequest } from './queryClient';
 import { initializeSkillTree } from './skillSystem';
 import { getCurrentUser } from './userStorage';
+import { getInitialUnlockedCommands } from './commands';
 
 const STORAGE_KEY = 'roguesim_game_state';
 const SESSION_KEY = 'roguesim_session_id';
@@ -11,7 +12,7 @@ const defaultGameState: GameState = {
   credits: 500,
   reputation: 'UNKNOWN',
   completedMissions: 0,
-  unlockedCommands: ['help', 'scan', 'connect', 'status', 'clear', 'devmode', 'multiplayer', 'mission-map', 'chat', 'team', 'players', 'login'],
+  unlockedCommands: getInitialUnlockedCommands(),
   missionProgress: 0,
   networkStatus: 'DISCONNECTED',
   soundEnabled: true,

--- a/client/src/lib/userProfileManager.ts
+++ b/client/src/lib/userProfileManager.ts
@@ -76,7 +76,7 @@ class UserProfileManager {
         
         // Initial unlocks
         unlockedAchievements: [],
-        unlockedCommands: ['help', 'scan', 'connect', 'missions'],
+        unlockedCommands: ['help', 'scan', 'connect', 'status', 'clear', 'shop', 'hackide'],
         unlockedPayloads: ['basic_payload'],
         
         // Empty save state

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -543,7 +543,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
                     credits: gameState?.credits || 1000,
                     reputation: gameState?.reputation || 'ROOKIE',
                     completedMissions: gameState?.completedMissions || 0,
-                    unlockedCommands: gameState?.unlockedCommands || ['help', 'scan', 'connect', 'status', 'clear'],
+                    unlockedCommands: gameState?.unlockedCommands || ['help', 'scan', 'connect', 'status', 'clear', 'shop', 'hackide'],
                     missionProgress: gameState?.missionProgress || 0,
                     networkStatus: gameState?.networkStatus || 'DISCONNECTED',
                     soundEnabled: gameState?.soundEnabled ?? true,

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -361,7 +361,7 @@ export class DatabaseStorage implements IStorage {
             preferredGameMode: 'single',
 
             unlockedAchievements: stats?.achievementsUnlocked || [],
-            unlockedCommands: ['help', 'scan', 'connect', 'missions'],
+            unlockedCommands: ['help', 'scan', 'connect', 'status', 'clear', 'shop', 'hackide'],
             unlockedPayloads: ['basic_payload'],
 
             currentGameState: null,

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -44,7 +44,7 @@ export const gameSaves = pgTable("game_saves", {
   credits: integer("credits").notNull().default(1000),
   reputation: text("reputation").notNull().default('ROOKIE'),
   completedMissions: integer("completed_missions").notNull().default(0),
-  unlockedCommands: text("unlocked_commands").array().notNull().default(['help', 'scan', 'connect', 'status', 'clear', 'man']),
+  unlockedCommands: text("unlocked_commands").array().notNull().default(['help', 'scan', 'connect', 'status', 'clear', 'shop', 'hackide', 'man']),
   missionProgress: integer("mission_progress").notNull().default(0),
   networkStatus: text("network_status").notNull().default('DISCONNECTED'),
   soundEnabled: boolean("sound_enabled").notNull().default(true),


### PR DESCRIPTION
## Summary
- include `hackide` in default command lists across frontend and backend
- centralize initial commands in `gameStorage` and `useGameState`

## Testing
- `npm run check` *(fails: TS1005 error)*

------
https://chatgpt.com/codex/tasks/task_e_6847de6d081c8332b2d7e4f1a773ac9b