### PR TITLE
Fix duplicate BinaryTreeGame name

### DIFF
--- a/client/src/components/MiniGameInterface.tsx
+++ b/client/src/components/MiniGameInterface.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect, useCallback } from 'react';
-import { MiniGameState, PatternCrackGame, SignalTraceGame, BinaryTreeGame } from '../types/game';
+import type { MiniGameState, PatternCrackGame, SignalTraceGame, BinaryTreeGame } from '../types/game';
 import { Clock, Target, Zap, ArrowUp, ArrowDown, ArrowLeft, ArrowRight } from 'lucide-react';
 
 interface MiniGameInterfaceProps {


### PR DESCRIPTION
## Summary
- mark `BinaryTreeGame` import as type-only

## Testing
- `npm run check` *(fails: server/routes.ts syntax errors)*

------
https://chatgpt.com/codex/tasks/task_e_68483ae008308332aa9109b4d6530dcd