### PR TITLE
Ensure hacker name returned and profile uses it

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -57,7 +57,7 @@ export default function App() {
           } else {
             // Create new profile for first-time user
             const newProfile = await userProfileManager.createProfile({
-              hackerName: user.hackerName || 'Anonymous_Hacker',
+              hackerName: user.hackerName,
               email: user.email || '',
               profileImageUrl: user.profileImageUrl || ''
             });


### PR DESCRIPTION
## Summary
- verify `/api/auth/verify` includes `hackerName` in response
- create profiles with the provided hacker name only

## Testing
- `npm run check` *(fails: Property 'readyState' does not exist and others)*

------
https://chatgpt.com/codex/tasks/task_e_684b9b237e9883328aa229d843d0d86e