### PR TITLE
Fix login reload logic

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -352,10 +352,14 @@ export default function App() {
 
   // Show login screen if not authenticated
   if (!isAuthenticated) {
-    return <LoginPage onLoginSuccess={(userData) => {
-      // Login will be handled by the backend and useAuth hook
-      window.location.reload();
-    }} />;
+    return (
+      <LoginPage
+        onLoginSuccess={() => {
+          // useAuth listens for login events, so just trigger re-fetch
+          window.dispatchEvent(new Event('userLoggedIn'));
+        }}
+      />
+    );
   }
 
   // Add effectiveUser for backward compatibility


### PR DESCRIPTION
## Summary
- dispatch an event instead of reloading after login

## Testing
- `npm run check` *(fails: Property 'readyState' does not exist, cannot find name 'wss', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_684ba1d6d5e0833291d48827a0ec7db3