### PR TITLE
Add server config validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,10 +60,16 @@ A full-stack web-based cyberpunk hacking simulation game featuring terminal-styl
    cp env.example .env
    ```
    
-   Edit `.env` with your configuration:
+   Edit `.env` with your configuration. The server validates these variables on
+   startup via `server/config.ts` and will exit if the required ones are missing:
    ```env
    DATABASE_URL=postgresql://username:password@hostname:5432/roguesim
    SESSION_SECRET=your-super-secret-session-key-at-least-32-characters-long
+   # Optional email service
+   SENDGRID_API_KEY=your-sendgrid-api-key
+   FROM_EMAIL=noreply@yourdomain.com
+   # Optional AI mission generation
+   OPENAI_API_KEY=your-openai-api-key
    NODE_ENV=development
    PORT=5000
    ```

--- a/env.example
+++ b/env.example
@@ -1,4 +1,6 @@
-# Database Configuration
+# Environment variables (validated by server/config.ts)
+
+# Database Configuration (REQUIRED)
 DATABASE_URL=postgresql://username:password@localhost:5432/roguesim
 # For Neon (production): postgresql://username:password@ep-xxx-xxx.region.aws.neon.tech/neondb?sslmode=require
 

--- a/server/config.ts
+++ b/server/config.ts
@@ -1,0 +1,24 @@
+import { z } from 'zod';
+
+const envSchema = z.object({
+  DATABASE_URL: z.string().min(1, 'DATABASE_URL is required'),
+  SESSION_SECRET: z.string().min(1, 'SESSION_SECRET is required'),
+  SENDGRID_API_KEY: z.string().optional(),
+  FROM_EMAIL: z.string().optional(),
+  OPENAI_API_KEY: z.string().optional(),
+  NODE_ENV: z.string().optional(),
+  PORT: z.string().optional(),
+  DOMAIN: z.string().optional(),
+  CLIENT_URL: z.string().optional(),
+  HOST: z.string().optional(),
+});
+
+const parsed = envSchema.safeParse(process.env);
+
+if (!parsed.success) {
+  console.error('Invalid environment variables', parsed.error.format());
+  throw new Error('Environment validation failed');
+}
+
+export const env = parsed.data;
+export type Env = typeof env;

--- a/server/index.ts
+++ b/server/index.ts
@@ -1,5 +1,6 @@
 // server/index.ts (PRODUCTION - FULL FRONTEND + API SERVING)
 import 'dotenv/config';
+import { env } from './config';
 import express, { type Request, Response, NextFunction } from "express";
 import { createServer } from "http";
 import { fileURLToPath } from 'url';
@@ -21,7 +22,7 @@ app.use(express.urlencoded({ extended: false }));
 
 // 2. CORS Middleware (BEFORE API routes)
 app.use(cors({
-    origin: process.env.CLIENT_URL || '*',
+    origin: env.CLIENT_URL || '*',
     credentials: true,
     methods: ['GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'OPTIONS'],
     allowedHeaders: ['Content-Type', 'Authorization', 'X-Requested-With', 'Accept'],
@@ -41,7 +42,7 @@ log('✅ CORS middleware configured.');
         log('✅ API routes registered successfully');
 
         // 5. Serve Static Files / SPA Fallback (AFTER API routes)
-    if (process.env.NODE_ENV === 'development') {
+    if (env.NODE_ENV === 'development') {
       const { setupVite } = await import('./vite.js');
       await setupVite(app, server);
             log('📁 Vite development server configured');
@@ -57,8 +58,8 @@ log('✅ CORS middleware configured.');
     });
 
         // 7. Start Server
-    const port = parseInt(process.env.PORT || "5000", 10);
-    const host = process.env.HOST || "0.0.0.0";
+    const port = parseInt(env.PORT || "5000", 10);
+    const host = env.HOST || "0.0.0.0";
     server.listen(port, host, () => {
             log(`🚀 Production server running on http://${host}:${port}`);
             log(`🎯 Frontend and API routes active!`);


### PR DESCRIPTION
## Summary
- add Zod-based environment validator in `server/config.ts`
- validate env in server startup and use typed values
- document env vars in README and env.example

## Testing
- `npm run check` *(fails: Property 'readyState' does not exist; cannot find name 'wss')*

------
https://chatgpt.com/codex/tasks/task_e_684f97603b948332b6cc5ca8012daa1c