### PR TITLE
Hash verification codes

### DIFF
--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -125,7 +125,8 @@ export const verificationCodes = pgTable("verification_codes", {
   id: serial("id").primaryKey(),
   email: varchar("email").notNull(),
   hackerName: varchar("hacker_name"),
-  code: varchar("code", { length: 6 }).notNull(),
+  // Store a hashed verification code (SHA-256 hex string)
+  code: varchar("code", { length: 64 }).notNull(),
   expiresAt: timestamp("expires_at").notNull(),
   used: boolean("used").notNull().default(false),
   createdAt: timestamp("created_at").notNull().defaultNow(),


### PR DESCRIPTION
## Summary
- store hashed verification codes with SHA-256
- verify codes by hashing user input
- expand verification code column length

## Testing
- `npm run check` *(fails: Property 'readyState' does not exist, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_684f97642ee88332a2771f888afaa11a