### PR TITLE
Fix Stripe env loading

### DIFF
--- a/env.example
+++ b/env.example
@@ -11,6 +11,10 @@ SESSION_SECRET=your-super-secret-session-key-at-least-32-characters-long
 SENDGRID_API_KEY=your-sendgrid-api-key
 FROM_EMAIL=noreply@yourdomain.com
 
+# Stripe Configuration
+STRIPE_SECRET_KEY=your-stripe-secret-key
+VITE_STRIPE_PUBLIC_KEY=your-stripe-public-key
+
 # OpenAI Configuration (Optional - for AI mission generation)
 OPENAI_API_KEY=your-openai-api-key
 

--- a/env.remote.example
+++ b/env.remote.example
@@ -17,6 +17,10 @@ SESSION_SECRET=your-super-secure-session-secret-here-change-this
 SESSION_SECURE=true
 SESSION_SAME_SITE=strict
 
+# Stripe Configuration
+STRIPE_SECRET_KEY=your-stripe-secret-key
+VITE_STRIPE_PUBLIC_KEY=your-stripe-public-key
+
 # CORS Settings
 CORS_CREDENTIALS=true
 

--- a/server/config.ts
+++ b/server/config.ts
@@ -11,6 +11,7 @@ const envSchema = z.object({
   DOMAIN: z.string().optional(),
   CLIENT_URL: z.string().optional(),
   HOST: z.string().optional(),
+  STRIPE_SECRET_KEY: z.string().optional(),
 });
 
 const parsed = envSchema.safeParse(process.env);

--- a/server/index.ts
+++ b/server/index.ts
@@ -1,18 +1,20 @@
 // server/index.ts (PRODUCTION - FULL FRONTEND + API SERVING)
-import 'dotenv/config';
+import dotenv from 'dotenv';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+// Resolve project root and load environment variables from .env
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+dotenv.config({ path: path.resolve(__dirname, '../.env') });
+
 import { env } from './config';
 import express, { type Request, Response, NextFunction } from "express";
 import { createServer } from "http";
-import { fileURLToPath } from 'url';
 import { registerRoutes } from "./routes";
 import { serveStatic, log } from "./vite";
 import { initDatabase } from "./db";
-import path from "path";
 import cors from "cors";
-
-// ES module equivalent of __dirname
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = path.dirname(__filename);
 
 const app = express();
 

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -15,6 +15,7 @@ import { log } from "./vite";
 import crypto from "crypto";
 import { SecurityMiddleware, PasswordValidator, SecurityAuditLogger } from "./security";
 import Stripe from "stripe";
+import { env } from './config';
 
 // Authentication middleware
 const isAuthenticated: RequestHandler = (req: any, res, next) => {
@@ -38,10 +39,10 @@ function generateSecureVerificationCode(): string {
 let storage: DatabaseStorage;
 
 // Initialize Stripe
-if (!process.env.STRIPE_SECRET_KEY) {
+if (!env.STRIPE_SECRET_KEY) {
     throw new Error('Missing required Stripe secret: STRIPE_SECRET_KEY');
 }
-const stripe = new Stripe(process.env.STRIPE_SECRET_KEY, {
+const stripe = new Stripe(env.STRIPE_SECRET_KEY, {
     apiVersion: "2025-06-30.basil",
 });
 

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -9,6 +9,8 @@ export default defineConfig({
   plugins: [
     react(),
   ],
+  // Load environment variables from project root
+  envDir: __dirname,
   resolve: {
     alias: {
       "@": path.resolve(__dirname, "client", "src"),


### PR DESCRIPTION
## Summary
- load server env vars from root `.env`
- validate `STRIPE_SECRET_KEY` in server config
- use parsed env for Stripe init
- load client env vars from root `.env`
- document stripe keys in `env.example` and `env.remote.example`

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run check` *(fails: TypeScript errors in broken files)*

------
https://chatgpt.com/codex/tasks/task_e_6864a01c43cc8332a2e1cfd7c6569000