### PR TITLE
Fix TypeScript build failing on backup files

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "include": ["client/src/**/*", "shared/**/*", "server/**/*"],
-  "exclude": ["node_modules", "build", "dist", "**/*.test.ts"],
+  "exclude": ["node_modules", "build", "dist", "**/*.test.ts", "**/*_broken.ts", "**/*_broken.tsx"],
   "compilerOptions": {
     "incremental": true,
     "tsBuildInfoFile": "./node_modules/typescript/tsbuildinfo",


### PR DESCRIPTION
## Summary
- exclude `*_broken.ts` and `*_broken.tsx` from tsconfig so type checking doesn't fail

## Testing
- `npm run check`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6864a2da40c88332a9d4db116b447efd