### PR TITLE
Fix viewport meta tag and html width

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1, user-scalable=no" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>RogueSim - Cyberpunk Hacking Simulation</title>
   </head>
   <body>

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -33,8 +33,8 @@
   /* Completely prevent horizontal scrollbars */
   html, body {
     overflow-x: hidden !important;
-    max-width: 100vw !important;
-    width: 100vw !important;
+    max-width: 100% !important;
+    width: 100% !important;
     position: relative;
   }
 


### PR DESCRIPTION
## Summary
- remove scaling restrictions from the main HTML file
- use percentage width for the global `html` and `body` rules
- run unit tests to ensure everything still builds

## Testing
- `npm test`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_687b94d2dec08332be1fa954f9f22d43