### PR TITLE
Enable CSRF protection

### DIFF
--- a/server/routes.ts
+++ b/server/routes.ts
@@ -9,6 +9,7 @@ import bcrypt from "bcryptjs";
 import { v4 as uuidv4 } from "uuid";
 import session from "express-session";
 import connectPg from "connect-pg-simple";
+import csurf from "csurf";
 import { sendVerificationEmail, sendWelcomeEmail } from "./emailService";
 import { logger, authLogger, sessionLogger, logAuthEvent, logUserAction } from "./logger";
 import { log } from "./vite";
@@ -82,6 +83,10 @@ export async function registerRoutes(app: Express): Promise<Server> {
         app.use(SecurityMiddleware.honeypotProtection());
         app.use(SecurityMiddleware.enhanceSessionSecurity());
 
+        // CSRF protection middleware
+        const csrfProtection = csurf();
+        app.use(csrfProtection);
+
         // Advanced rate limiting for authentication routes
         const authLimiter = SecurityMiddleware.advancedRateLimit({
             windowMs: 15 * 60 * 1000,
@@ -100,7 +105,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
 
         // CSRF token endpoint
         app.get('/api/csrf', (req, res) => {
-            res.json({ csrfToken: 'disabled' });
+            res.json({ csrfToken: req.csrfToken() });
         });
 
         // Basic health check endpoint for Docker (without database dependency)

--- a/tests/csrf-auth.test.ts
+++ b/tests/csrf-auth.test.ts
@@ -1,0 +1,62 @@
+import request from 'supertest';
+import express from 'express';
+import session from 'express-session';
+import csurf from 'csurf';
+import { beforeAll, test, expect } from 'vitest';
+
+let app: express.Express;
+let agent: request.SuperAgentTest;
+const users: Record<string, any> = {};
+
+const isAuthenticated: express.RequestHandler = (req, res, next) => {
+  if (req.session && req.session.userId) return next();
+  return res.status(401).json({ error: 'auth' });
+};
+
+beforeAll(() => {
+  app = express();
+  app.use(express.json());
+  app.use(session({ secret: 'test-secret', resave: false, saveUninitialized: false }));
+  app.use(csurf());
+
+  app.get('/api/csrf', (req, res) => {
+    res.json({ csrfToken: req.csrfToken() });
+  });
+
+  app.post('/api/auth/login', (req, res) => {
+    const { email, password } = req.body;
+    const user = users[email];
+    if (!user || user.password !== password) return res.status(401).json({ error: 'invalid' });
+    req.session.userId = email;
+    res.json({ user: { id: email } });
+  });
+
+  app.post('/api/missions/generate', isAuthenticated, (_req, res) => {
+    res.json({ mission: true });
+  });
+
+  users['a@b.c'] = { password: 'p' };
+
+  agent = request.agent(app);
+});
+
+test('login and generate mission with CSRF token', async () => {
+  const tokenRes = await agent.get('/api/csrf');
+  const token = tokenRes.body.csrfToken;
+  expect(token).toBeTruthy();
+
+  const loginRes = await agent
+    .post('/api/auth/login')
+    .set('x-csrf-token', token)
+    .send({ email: 'a@b.c', password: 'p' });
+  expect(loginRes.status).toBe(200);
+
+  const newTokenRes = await agent.get('/api/csrf');
+  const token2 = newTokenRes.body.csrfToken;
+  const missionRes = await agent
+    .post('/api/missions/generate')
+    .set('x-csrf-token', token2)
+    .send({});
+  expect(missionRes.status).toBe(200);
+  expect(missionRes.body.mission).toBe(true);
+});


### PR DESCRIPTION
## Summary
- enable csurf middleware and expose `/api/csrf`
- include new vitest test covering login and mission generation with CSRF

## Testing
- `npx vitest run`
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_687b945b0d1c833281ca3f4e474dad55