### PR TITLE
Fix skill level updates & add training missions

### DIFF
--- a/client/src/components/SkillTreeInterface.tsx
+++ b/client/src/components/SkillTreeInterface.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import { GameState, SkillNode } from '../types/game';
 import { 
   skillCategories, 
@@ -17,6 +17,15 @@ interface SkillTreeInterfaceProps {
 export function SkillTreeInterface({ gameState, onSkillPurchase, onClose }: SkillTreeInterfaceProps) {
   const [activeCategory, setActiveCategory] = useState<'offensive' | 'defensive' | 'social'>('offensive');
   const [selectedSkill, setSelectedSkill] = useState<SkillNode | null>(null);
+
+  // Keep selected skill in sync when the skill tree updates
+  useEffect(() => {
+    if (!selectedSkill) return;
+    const updated = gameState.skillTree.nodes.find(n => n.id === selectedSkill.id);
+    if (updated) {
+      setSelectedSkill(updated);
+    }
+  }, [gameState.skillTree, selectedSkill?.id]);
   
   // Safety check for gameState and skillTree
   if (!gameState || !gameState.skillTree || !gameState.skillTree.nodes) {
@@ -62,6 +71,13 @@ export function SkillTreeInterface({ gameState, onSkillPurchase, onClose }: Skil
     const canPurchase = canPurchaseSkill(skillId, gameState.skillTree);
     if (canPurchase.canPurchase) {
       onSkillPurchase(skillId);
+      // Optimistically update selected skill level to reflect purchase immediately
+      setSelectedSkill(prev => {
+        if (prev && prev.id === skillId) {
+          return { ...prev, purchased: true, currentLevel: prev.currentLevel + 1 };
+        }
+        return prev;
+      });
     }
   };
   

--- a/client/src/lib/missionDatabase.ts
+++ b/client/src/lib/missionDatabase.ts
@@ -188,6 +188,102 @@ export const standardMissions: Mission[] = [
   },
 
   {
+    id: 'offensive_bootcamp',
+    title: 'Offensive Bootcamp',
+    description: 'Practice exploitation basics in a controlled environment.',
+    briefing: 'Hone your offensive skills against simulated targets.',
+    difficulty: 'EASY',
+    category: 'INFILTRATION',
+    type: 'STANDARD',
+    requiredLevel: 2,
+    creditReward: 150,
+    experienceReward: 75,
+    skillPointReward: 1,
+    isRepeatable: true,
+    objectives: [
+      {
+        id: 'exploit_training',
+        description: 'Run a basic exploit',
+        type: 'COMMAND',
+        command: 'exploit',
+        completed: false
+      },
+      {
+        id: 'escalate_training',
+        description: 'Escalate privileges',
+        type: 'COMMAND',
+        command: 'escalate',
+        completed: false
+      }
+    ],
+    unlocks: ['exploit', 'escalate']
+  },
+
+  {
+    id: 'defensive_drill',
+    title: 'Defensive Systems Drill',
+    description: 'Test your defensive protocols against incoming attacks.',
+    briefing: 'Stop simulated intrusions and secure the system.',
+    difficulty: 'EASY',
+    category: 'EXTRACTION',
+    type: 'STANDARD',
+    requiredLevel: 2,
+    creditReward: 150,
+    experienceReward: 75,
+    skillPointReward: 1,
+    isRepeatable: true,
+    objectives: [
+      {
+        id: 'deploy_defenses',
+        description: 'Activate basic defenses',
+        type: 'COMMAND',
+        command: 'defend',
+        completed: false
+      },
+      {
+        id: 'analyze_logs',
+        description: 'Analyze intrusion logs',
+        type: 'COMMAND',
+        command: 'analyze logs',
+        completed: false
+      }
+    ],
+    unlocks: ['defend', 'analyze']
+  },
+
+  {
+    id: 'social_training',
+    title: 'Social Engineering 101',
+    description: 'Learn fundamental manipulation techniques.',
+    briefing: 'Practice phishing and persuasion on volunteer targets.',
+    difficulty: 'EASY',
+    category: 'SOCIAL_ENGINEERING',
+    type: 'STANDARD',
+    requiredLevel: 2,
+    creditReward: 150,
+    experienceReward: 75,
+    skillPointReward: 1,
+    isRepeatable: true,
+    objectives: [
+      {
+        id: 'gather_info',
+        description: 'Gather basic intel',
+        type: 'COMMAND',
+        command: 'gather intel',
+        completed: false
+      },
+      {
+        id: 'phish_target',
+        description: 'Send a phishing email',
+        type: 'COMMAND',
+        command: 'phish',
+        completed: false
+      }
+    ],
+    unlocks: ['phish', 'social_engineering']
+  },
+
+  {
     id: 'government_breach',
     title: 'Shadow Government',
     description: 'Infiltrate classified government systems to uncover hidden operations.',

--- a/tests/skill-purchase.test.ts
+++ b/tests/skill-purchase.test.ts
@@ -1,0 +1,13 @@
+import { test, expect } from 'vitest';
+import { initializeSkillTree, purchaseSkill } from '../client/src/lib/skillSystem';
+
+test('purchasing a skill increases its level and reduces skill points', () => {
+  const tree = initializeSkillTree();
+  const skill = tree.nodes.find(s => s.unlocked && !s.purchased)!;
+  const startingPoints = tree.skillPoints;
+  const { skillTree } = purchaseSkill(skill.id, tree);
+  const updated = skillTree.nodes.find(n => n.id === skill.id)!;
+  expect(updated.purchased).toBe(true);
+  expect(updated.currentLevel).toBe(skill.currentLevel + 1);
+  expect(skillTree.skillPoints).toBe(startingPoints - skill.cost);
+});


### PR DESCRIPTION
## Summary
- update skill tree interface to sync selected skill level with game state
- add training missions to practice offensive, defensive and social skills
- test skill purchasing behaviour

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687b9d4bad0c8332986896be9b6d8bfa