### PR TITLE
chore: enable verification code logging in production compose

### DIFF
--- a/docker-compose.production.yml
+++ b/docker-compose.production.yml
@@ -9,6 +9,7 @@ services:
       - NODE_ENV=production
       - PORT=5000
       - HOST=0.0.0.0
+      - VERIFICATION_LOGGING=true
     env_file:
       - .env
     healthcheck:


### PR DESCRIPTION
## Summary
- add `VERIFICATION_LOGGING` env flag to production compose so verification codes are logged during registration

## Testing
- `docker-compose build --no-cache` *(fails: Error while fetching server API version)*
- `docker-compose up -d` *(fails: Error while fetching server API version)*
- `curl -fsS http://localhost:8000/health` *(fails: couldn't connect to server)*

------
https://chatgpt.com/codex/tasks/task_e_689af59c3f988332b313641a20bd0229