### PR TITLE
Fix App hook ordering before conditional returns

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -217,6 +217,20 @@ export default function App() {
     }
   }, []);
 
+  const handleMissionProgressionUpdate = useCallback(
+    (progression: MissionProgressionState) => {
+      updateGameState({ missionProgression: progression });
+    },
+    [updateGameState]
+  );
+
+  const handleDynamicMissionPoolUpdate = useCallback(
+    (missions: Mission[]) => {
+      updateGameState({ dynamicMissionDeck: missions });
+    },
+    [updateGameState]
+  );
+
   // Show loading while authentication is being determined
   if (authLoading || gameLoading) {
     return (
@@ -348,20 +362,6 @@ export default function App() {
 
     setShowMissionInterface(false);
   };
-
-  const handleMissionProgressionUpdate = useCallback(
-    (progression: MissionProgressionState) => {
-      updateGameState({ missionProgression: progression });
-    },
-    [updateGameState]
-  );
-
-  const handleDynamicMissionPoolUpdate = useCallback(
-    (missions: Mission[]) => {
-      updateGameState({ dynamicMissionDeck: missions });
-    },
-    [updateGameState]
-  );
 
   const handleMiniGameComplete = (success: boolean, score: number) => {
     if (activeMiniGame && activeMiniGame.currentGame) {


### PR DESCRIPTION
### Motivation
- Eliminate React error #310 caused by hooks being conditionally skipped due to early `return` branches so the app can render loading, login, username-setup, and main game states without crashing.

### Description
- Move the two mission-related `useCallback` hooks (`handleMissionProgressionUpdate` and `handleDynamicMissionPoolUpdate`) to execute unconditionally before any conditional `return` statements in `client/src/App.tsx`, preserving TypeScript types and hook dependencies and changing no other logic.

### Testing
- Attempted to run deployment/test commands: `docker compose build --no-cache && docker compose up -d` (failed: `docker` not available in this environment) and `curl -fsS http://localhost:8000/health` (failed: connection refused), and the change was committed successfully with the required message.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697c3d51fc4c8332be1c2f2b2549e3e8)